### PR TITLE
Small syntax fix

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -6,7 +6,7 @@ module.exports = function(cfg) {
   cfg.endpoint = "http://" + cfg.address + ":" + cfg.restPort;
 
   this.info = function(req, res) {
-    res.status(200).json({cfg});
+    res.status(200).json(cfg);
   };
 
   this.oauth = oauth(cfg);


### PR DESCRIPTION
```
vagrant@localhost ~ $ /home/vagrant/tutorial/cloud9/start.sh
Starting test-config
Connect server listening at http://10.0.2.15:9000
CDN: version standalone initialized /home/vagrant/tutorial/cloud9/build

/home/vagrant/tutorial/cloud9/plugins/snlab.devopen.server/lib/test.js:9
    res.status(200).json({cfg});
                             ^
Trace: Error while starting '/home/vagrant/tutorial/cloud9/configs/test-config':
    at /home/vagrant/tutorial/cloud9/server.js:223:25
    at Architect.done (/home/vagrant/tutorial/cloud9/node_modules/architect/architect.js:587:9)
    at Architect.emit (events.js:95:17)
    at startPlugins (/home/vagrant/tutorial/cloud9/node_modules/architect/architect.js:468:21)
    at startPlugins (/home/vagrant/tutorial/cloud9/node_modules/architect/architect.js:473:21)
    at register (/home/vagrant/tutorial/cloud9/node_modules/architect/architect.js:504:13)
    at Server.<anonymous> (/home/vagrant/tutorial/cloud9/node_modules/connect-architect/connect/connect-plugin.js:135:13)
    at Server.g (events.js:180:16)
    at Server.emit (events.js:92:17)
    at net.js:1056:10
{ [SyntaxError: Unexpected token }]
  plugin:
   { packagePath: '/home/vagrant/tutorial/cloud9/plugins/snlab.devopen.server/managerd.js',
     provides: [ 'controller.managerd' ],
     consumes: [ 'Plugin' ],
     setup: { [Function: main] consumes: [Object], provides: [Object] } } } 'SyntaxError: Unexpected token }\n    at Module._compile (module.js:439:25)\n    at Module.module.constructor._compile (/home/vagrant/tutorial/cloud9/node_modules/amd-loader/amd-loader.js:10:31)\n    at Object.Module._extensions..js (module.js:474:10)\n    at Module.load (module.js:356:32)\n    at Function.Module._load (module.js:312:12)\n    at Module.require (module.js:364:17)\n    at require (module.js:380:17)\n    at Object.<anonymous> (/home/vagrant/tutorial/cloud9/plugins/snlab.devopen.server/portalApp.js:8:15)\n    at Module._compile (module.js:456:26)\n    at Module.module.constructor._compile (/home/vagrant/tutorial/cloud9/node_modules/amd-loader/amd-loader.js:10:31)'
```
